### PR TITLE
ci: docker build and scan

### DIFF
--- a/.github/workflows/docker-build-go.yml
+++ b/.github/workflows/docker-build-go.yml
@@ -1,7 +1,11 @@
 name: Docker Build & Push (Go)
 
-# Reusable workflow: builds a Go service Docker image and pushes to GHCR.
-# Designed for Go microservices; create docker-build-node.yml etc. for other stacks.
+# Reusable workflow: builds a Go service Docker image, scans for vulnerabilities,
+# and pushes to GHCR only if the scan passes.
+#
+# Security: When scan-before-push is enabled (default), the image is built locally
+# (--load), scanned with Trivy, and only pushed if no vulnerabilities are found.
+# This prevents vulnerable images from reaching the registry.
 
 on:
   workflow_call:
@@ -50,6 +54,26 @@ on:
         required: false
         type: boolean
         default: false
+      scan-before-push:
+        description: 'Scan image with Trivy before pushing to registry'
+        required: false
+        type: boolean
+        default: true
+      scan-severity:
+        description: 'Trivy severity filter for pre-push scan (e.g. CRITICAL,HIGH)'
+        required: false
+        type: string
+        default: 'CRITICAL,HIGH'
+      scan-exit-code:
+        description: 'Trivy exit code on vulnerability found (0=warn only, 1=block push)'
+        required: false
+        type: string
+        default: '1'
+      scan-ignore-unfixed:
+        description: 'Ignore vulnerabilities without a fix available'
+        required: false
+        type: boolean
+        default: true
 
     outputs:
       tags:
@@ -58,6 +82,9 @@ on:
       digest:
         description: 'Image digest'
         value: ${{ jobs.build.outputs.digest }}
+      scan-status:
+        description: 'Pre-push scan result: pass, fail, or skipped'
+        value: ${{ jobs.build.outputs.scan-status }}
 
 jobs:
   build:
@@ -70,7 +97,8 @@ jobs:
 
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
-      digest: ${{ steps.build.outputs.digest }}
+      digest: ${{ steps.push.outputs.digest }}
+      scan-status: ${{ steps.scan-result.outputs.status }}
 
     steps:
       - name: Checkout
@@ -105,14 +133,64 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             ${{ inputs.tags }}
 
-      - name: Build and push Docker image
-        id: build
+      # ── Build locally for scanning (--load, single platform) ──
+      - name: Build image (local)
+        id: build-local
+        if: inputs.push && inputs.scan-before-push
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile }}
+          load: true
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ inputs.build-args }}
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository }}/${{ inputs.image-name }}:cache-main
+            type=registry,ref=ghcr.io/${{ github.repository }}/${{ inputs.image-name }}:cache-${{ github.ref_name }}
+          provenance: false
+
+      # ── Trivy scan (local image, before push) ──
+      - name: Trivy pre-push scan
+        id: trivy
+        if: inputs.push && inputs.scan-before-push
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+          format: 'table'
+          severity: ${{ inputs.scan-severity }}
+          exit-code: ${{ inputs.scan-exit-code }}
+          ignore-unfixed: ${{ inputs.scan-ignore-unfixed }}
+          scanners: 'vuln'
+
+      # ── Determine scan result ──
+      - name: Set scan result
+        id: scan-result
+        if: always()
+        run: |
+          if [ "${{ inputs.scan-before-push }}" != "true" ] || [ "${{ inputs.push }}" != "true" ]; then
+            echo "status=skipped" >> $GITHUB_OUTPUT
+          elif [ "${{ steps.trivy.outcome }}" == "success" ]; then
+            echo "status=pass" >> $GITHUB_OUTPUT
+          else
+            echo "status=fail" >> $GITHUB_OUTPUT
+          fi
+
+      # ── Push to registry (only if scan passed or scanning disabled) ──
+      - name: Push image to registry
+        id: push
+        if: >-
+          inputs.push && (
+            !inputs.scan-before-push ||
+            steps.trivy.outcome == 'success'
+          )
         uses: docker/build-push-action@v7
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}
           platforms: ${{ inputs.platforms }}
-          push: ${{ inputs.push }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: ${{ inputs.build-args }}
@@ -123,13 +201,66 @@ jobs:
           provenance: true
           sbom: ${{ inputs.sbom }}
 
+      # ── Build without scan (when scan-before-push is false) ──
+      - name: Build and push (no pre-scan)
+        id: build-no-scan
+        if: inputs.push && !inputs.scan-before-push
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile }}
+          platforms: ${{ inputs.platforms }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ inputs.build-args }}
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository }}/${{ inputs.image-name }}:cache-main
+            type=registry,ref=ghcr.io/${{ github.repository }}/${{ inputs.image-name }}:cache-${{ github.ref_name }}
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/${{ inputs.image-name }}:cache-${{ github.ref_name }},mode=max
+          provenance: true
+          sbom: ${{ inputs.sbom }}
+
+      # ── Build only (no push) ──
+      - name: Build image (no push)
+        id: build-only
+        if: '!inputs.push && !inputs.scan-before-push'
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile }}
+          platforms: ${{ inputs.platforms }}
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ inputs.build-args }}
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository }}/${{ inputs.image-name }}:cache-main
+            type=registry,ref=ghcr.io/${{ github.repository }}/${{ inputs.image-name }}:cache-${{ github.ref_name }}
+          provenance: false
+
       - name: Generate build summary
+        if: always()
         run: |
+          DIGEST="${{ steps.push.outputs.digest || steps.build-no-scan.outputs.digest || 'N/A (not pushed)' }}"
+          PUSHED="false"
+          if [ -n "${{ steps.push.outputs.digest }}" ] || [ -n "${{ steps.build-no-scan.outputs.digest }}" ]; then
+            PUSHED="true"
+          fi
+
           echo "## Docker Build Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
           echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
           echo "| Image | \`${{ inputs.image-name }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| Tags | ${{ steps.meta.outputs.tags }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Digest | \`${{ steps.build.outputs.digest }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| Pushed | ${{ inputs.push }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Digest | \`${DIGEST}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Pushed | ${PUSHED} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Pre-push Scan | **${{ steps.scan-result.outputs.status }}** |" >> $GITHUB_STEP_SUMMARY
+
+      # ── Fail job if scan failed (ensures the job status reflects the scan) ──
+      - name: Fail on scan failure
+        if: always() && steps.scan-result.outputs.status == 'fail'
+        run: |
+          echo "::error::Pre-push Trivy scan failed: vulnerabilities found matching severity filter (${{ inputs.scan-severity }}). Image was NOT pushed to registry."
+          exit 1

--- a/.github/workflows/docker-build-node.yml
+++ b/.github/workflows/docker-build-node.yml
@@ -1,7 +1,11 @@
 name: Docker Build & Push (Node)
 
-# Reusable workflow: builds a Node.js service Docker image and pushes to GHCR.
-# Designed for Node/frontend services; see docker-build-go.yml for Go services.
+# Reusable workflow: builds a Node.js service Docker image, scans for vulnerabilities,
+# and pushes to GHCR only if the scan passes.
+#
+# Security: When scan-before-push is enabled (default), the image is built locally
+# (--load), scanned with Trivy, and only pushed if no vulnerabilities are found.
+# This prevents vulnerable images from reaching the registry.
 
 on:
   workflow_call:
@@ -50,6 +54,26 @@ on:
         required: false
         type: boolean
         default: false
+      scan-before-push:
+        description: 'Scan image with Trivy before pushing to registry'
+        required: false
+        type: boolean
+        default: true
+      scan-severity:
+        description: 'Trivy severity filter for pre-push scan (e.g. CRITICAL,HIGH)'
+        required: false
+        type: string
+        default: 'CRITICAL,HIGH'
+      scan-exit-code:
+        description: 'Trivy exit code on vulnerability found (0=warn only, 1=block push)'
+        required: false
+        type: string
+        default: '1'
+      scan-ignore-unfixed:
+        description: 'Ignore vulnerabilities without a fix available'
+        required: false
+        type: boolean
+        default: true
 
     outputs:
       tags:
@@ -58,6 +82,9 @@ on:
       digest:
         description: 'Image digest'
         value: ${{ jobs.build.outputs.digest }}
+      scan-status:
+        description: 'Pre-push scan result: pass, fail, or skipped'
+        value: ${{ jobs.build.outputs.scan-status }}
 
 jobs:
   build:
@@ -70,7 +97,8 @@ jobs:
 
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
-      digest: ${{ steps.build.outputs.digest }}
+      digest: ${{ steps.push.outputs.digest }}
+      scan-status: ${{ steps.scan-result.outputs.status }}
 
     steps:
       - name: Checkout
@@ -105,14 +133,64 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             ${{ inputs.tags }}
 
-      - name: Build and push Docker image
-        id: build
+      # ── Build locally for scanning (--load, single platform) ──
+      - name: Build image (local)
+        id: build-local
+        if: inputs.push && inputs.scan-before-push
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile }}
+          load: true
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ inputs.build-args }}
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository }}/${{ inputs.image-name }}:cache-main
+            type=registry,ref=ghcr.io/${{ github.repository }}/${{ inputs.image-name }}:cache-${{ github.ref_name }}
+          provenance: false
+
+      # ── Trivy scan (local image, before push) ──
+      - name: Trivy pre-push scan
+        id: trivy
+        if: inputs.push && inputs.scan-before-push
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+          format: 'table'
+          severity: ${{ inputs.scan-severity }}
+          exit-code: ${{ inputs.scan-exit-code }}
+          ignore-unfixed: ${{ inputs.scan-ignore-unfixed }}
+          scanners: 'vuln'
+
+      # ── Determine scan result ──
+      - name: Set scan result
+        id: scan-result
+        if: always()
+        run: |
+          if [ "${{ inputs.scan-before-push }}" != "true" ] || [ "${{ inputs.push }}" != "true" ]; then
+            echo "status=skipped" >> $GITHUB_OUTPUT
+          elif [ "${{ steps.trivy.outcome }}" == "success" ]; then
+            echo "status=pass" >> $GITHUB_OUTPUT
+          else
+            echo "status=fail" >> $GITHUB_OUTPUT
+          fi
+
+      # ── Push to registry (only if scan passed or scanning disabled) ──
+      - name: Push image to registry
+        id: push
+        if: >-
+          inputs.push && (
+            !inputs.scan-before-push ||
+            steps.trivy.outcome == 'success'
+          )
         uses: docker/build-push-action@v7
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}
           platforms: ${{ inputs.platforms }}
-          push: ${{ inputs.push }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: ${{ inputs.build-args }}
@@ -123,13 +201,66 @@ jobs:
           provenance: true
           sbom: ${{ inputs.sbom }}
 
+      # ── Build without scan (when scan-before-push is false) ──
+      - name: Build and push (no pre-scan)
+        id: build-no-scan
+        if: inputs.push && !inputs.scan-before-push
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile }}
+          platforms: ${{ inputs.platforms }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ inputs.build-args }}
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository }}/${{ inputs.image-name }}:cache-main
+            type=registry,ref=ghcr.io/${{ github.repository }}/${{ inputs.image-name }}:cache-${{ github.ref_name }}
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/${{ inputs.image-name }}:cache-${{ github.ref_name }},mode=max
+          provenance: true
+          sbom: ${{ inputs.sbom }}
+
+      # ── Build only (no push) ──
+      - name: Build image (no push)
+        id: build-only
+        if: '!inputs.push && !inputs.scan-before-push'
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile }}
+          platforms: ${{ inputs.platforms }}
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ inputs.build-args }}
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository }}/${{ inputs.image-name }}:cache-main
+            type=registry,ref=ghcr.io/${{ github.repository }}/${{ inputs.image-name }}:cache-${{ github.ref_name }}
+          provenance: false
+
       - name: Generate build summary
+        if: always()
         run: |
+          DIGEST="${{ steps.push.outputs.digest || steps.build-no-scan.outputs.digest || 'N/A (not pushed)' }}"
+          PUSHED="false"
+          if [ -n "${{ steps.push.outputs.digest }}" ] || [ -n "${{ steps.build-no-scan.outputs.digest }}" ]; then
+            PUSHED="true"
+          fi
+
           echo "## Docker Build Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
           echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
           echo "| Image | \`${{ inputs.image-name }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| Tags | ${{ steps.meta.outputs.tags }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Digest | \`${{ steps.build.outputs.digest }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| Pushed | ${{ inputs.push }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Digest | \`${DIGEST}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Pushed | ${PUSHED} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Pre-push Scan | **${{ steps.scan-result.outputs.status }}** |" >> $GITHUB_STEP_SUMMARY
+
+      # ── Fail job if scan failed (ensures the job status reflects the scan) ──
+      - name: Fail on scan failure
+        if: always() && steps.scan-result.outputs.status == 'fail'
+        run: |
+          echo "::error::Pre-push Trivy scan failed: vulnerabilities found matching severity filter (${{ inputs.scan-severity }}). Image was NOT pushed to registry."
+          exit 1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Centralized reusable workflows for consistent CI/CD across all repositories
 
-## 🚀 Quick Start
+## Quick Start
 
 Use any workflow by referencing it with the `uses` keyword:
 
@@ -21,29 +21,30 @@ jobs:
     secrets: inherit
 ```
 
-## 📁 Available Workflows
+## Available Workflows
 
 | Workflow | Purpose | Features |
 |----------|---------|----------|
 | **[pr-checks.yml](.github/workflows/pr-checks.yml)** | PR handling | Branch validation, CODEOWNERS, Slack notifications |
 | **[go-check.yml](.github/workflows/go-check.yml)** | Go code quality | Tests, linting, coverage artifacts |
 | **[gitleaks.yml](.github/workflows/gitleaks.yml)** | Secret scanning (source) | Gitleaks CLI, PR diff / full scan, SARIF, job summary |
-| **[docker-build-go.yml](.github/workflows/docker-build-go.yml)** | Docker build (Go) | Multi-platform, caching, provenance, outputs `tags` + `digest` |
-| **[trivy-scan.yml](.github/workflows/trivy-scan.yml)** | Image vulnerability scan | Trivy, SARIF, Google Sheets reporting |
+| **[docker-build-go.yml](.github/workflows/docker-build-go.yml)** | Docker build (Go) | **Scan-before-push**, multi-platform, caching, provenance, outputs `tags` + `digest` + `scan-status` |
+| **[docker-build-node.yml](.github/workflows/docker-build-node.yml)** | Docker build (Node) | **Scan-before-push**, multi-platform, caching, provenance, outputs `tags` + `digest` + `scan-status` |
+| **[trivy-scan.yml](.github/workflows/trivy-scan.yml)** | Image vulnerability report | Trivy post-push scan, SARIF, Google Sheets reporting |
 | **[docker-sign.yml](.github/workflows/docker-sign.yml)** | Cosign image signing | Keyless OIDC signing |
 | **[sonarqube.yml](.github/workflows/sonarqube.yml)** | SonarCloud analysis | Go coverage, Quality Gate |
 | **[tf-lint.yml](.github/workflows/tf-lint.yml)** | Terraform validation | Format check, TFLint analysis |
 | **[status.yml](.github/workflows/status.yml)** | Build notifications | Slack, Google Sheets, job summaries |
 
-> **Pipeline pattern:** Service repos chain workflows explicitly: `docker-build-go.yml` → `trivy-scan.yml` → `docker-sign.yml`. Each builder (Go, Node, Python...) outputs `tags` + `digest` consumed by the shared scan and sign workflows.
+> **Pipeline pattern:** Builder workflows (`docker-build-go.yml`, `docker-build-node.yml`) now include integrated Trivy scanning **before push**. Images are only pushed to GHCR if the scan passes. `trivy-scan.yml` remains available for optional post-push SARIF reporting.
 
 ---
 
-> 📖 **For detailed workflow documentation, inputs, outputs, and complete examples**, see [USAGE.md](USAGE.md)
+> For detailed workflow documentation, inputs, outputs, and complete examples, see [USAGE.md](USAGE.md)
 
 ---
 
-## 💡 Quick Examples
+## Quick Examples
 
 **Go Project:**
 ```yaml
@@ -69,7 +70,37 @@ jobs:
       security-events: write
 ```
 
-**Docker Build -> Scan -> Sign Pipeline:**
+**Docker Build with Scan-Before-Push (recommended):**
+```yaml
+jobs:
+  build:
+    uses: duyhenryer/shared-workflows/.github/workflows/docker-build-go.yml@main
+    with:
+      image-name: my-service
+      push: true
+      scan-before-push: true        # default: true
+      scan-severity: 'CRITICAL,HIGH'
+      scan-exit-code: '1'
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+
+  sign:
+    needs: [build]
+    uses: duyhenryer/shared-workflows/.github/workflows/docker-sign.yml@main
+    with:
+      tags: ${{ needs.build.outputs.tags }}
+      digest: ${{ needs.build.outputs.digest }}
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+```
+
+**Docker Build with Post-Push Reporting (optional):**
 ```yaml
 jobs:
   build:
@@ -83,13 +114,15 @@ jobs:
       packages: write
       actions: read
 
-  scan:
+  # Optional: detailed SARIF + Google Sheets reporting
+  trivy-report:
     needs: [build]
+    if: needs.build.outputs.scan-status == 'pass'
     uses: duyhenryer/shared-workflows/.github/workflows/trivy-scan.yml@main
     with:
       image-ref: ghcr.io/${{ github.repository }}/my-service@${{ needs.build.outputs.digest }}
-      severity: 'CRITICAL,HIGH'
-      exit-code: '1'
+      severity: 'CRITICAL,HIGH,MEDIUM'
+      exit-code: '0'
       ignore-unfixed: true
     secrets: inherit
     permissions:
@@ -98,7 +131,7 @@ jobs:
       security-events: write
 
   sign:
-    needs: [build, scan]
+    needs: [build]
     uses: duyhenryer/shared-workflows/.github/workflows/docker-sign.yml@main
     with:
       tags: ${{ needs.build.outputs.tags }}
@@ -131,7 +164,7 @@ jobs:
 
 ---
 
-## 🔐 Required Secrets
+## Required Secrets
 
 | Secret | Used By | Required | Description |
 |--------|---------|----------|-------------|
@@ -140,11 +173,11 @@ jobs:
 | `GSHEET_CLIENT_EMAIL` | status.yml, trivy-scan.yml | No | Google service account email (Sheets reporting) |
 | `GSHEET_PRIVATE_KEY` | status.yml, trivy-scan.yml | No | Google service account private key (Sheets reporting) |
 
-Add in repository: Settings → Secrets and variables → Actions
+Add in repository: Settings > Secrets and variables > Actions
 
 ---
 
-## 📚 Documentation
+## Documentation
 
 - **[USAGE.md](USAGE.md)** - Complete workflow documentation with examples
 - **[.github/workflows/](.github/workflows/)** - Workflow source files

--- a/USAGE.md
+++ b/USAGE.md
@@ -138,10 +138,12 @@ jobs:
 
 ## docker-build-go.yml
 
-**Purpose:** Build a Go service Docker image and push to GHCR
-**Features:** Multi-platform builds, registry caching, provenance, SBOM, default tagging via `docker/metadata-action`
+**Purpose:** Build a Go service Docker image, scan for vulnerabilities, and push to GHCR only if clean
+**Features:** **Scan-before-push** (Trivy), multi-platform builds, registry caching, provenance, SBOM, default tagging via `docker/metadata-action`
 
-> This is the **Go-specific builder**. It outputs `tags` and `digest` that can be consumed by `trivy-scan.yml` and `docker-sign.yml`. For other stacks, create `docker-build-node.yml`, `docker-build-python.yml`, etc. with the same output interface.
+> This is the **Go-specific builder**. It outputs `tags`, `digest`, and `scan-status` that can be consumed by `docker-sign.yml` and optionally `trivy-scan.yml` (for reporting). For other stacks, see `docker-build-node.yml`, `docker-build-python.yml`, etc. with the same output interface.
+
+> **Security**: When `scan-before-push` is enabled (default), the image is built locally (`--load`), scanned with Trivy, and only pushed to GHCR if no vulnerabilities matching the severity filter are found. This prevents FluxCD from auto-deploying vulnerable images.
 
 ### Inputs
 
@@ -156,6 +158,10 @@ jobs:
 | `tags` | string | `""` | No | Custom tags (comma-separated); empty = default tagging |
 | `runs-on` | string | `"ubuntu-latest"` | No | Runner type |
 | `sbom` | boolean | `false` | No | Generate SBOM attestation |
+| `scan-before-push` | boolean | `true` | No | Scan image with Trivy before pushing to registry |
+| `scan-severity` | string | `"CRITICAL,HIGH"` | No | Trivy severity filter for pre-push scan |
+| `scan-exit-code` | string | `"1"` | No | Trivy exit code on vulnerability found (`0`=warn, `1`=block push) |
+| `scan-ignore-unfixed` | boolean | `true` | No | Ignore vulnerabilities without a fix available |
 
 ### Outputs
 
@@ -163,9 +169,11 @@ jobs:
 |--------|-------------|
 | `tags` | Generated image tags (newline-separated) |
 | `digest` | Image digest (`sha256:...`) |
+| `scan-status` | Pre-push scan result: `pass`, `fail`, or `skipped` |
 
 ### Usage
 
+**With scan-before-push (default, recommended):**
 ```yaml
 jobs:
   build:
@@ -173,12 +181,33 @@ jobs:
     with:
       image-name: my-service
       push: true
+      # scan-before-push: true      # default
+      # scan-severity: 'CRITICAL,HIGH'  # default
+      # scan-exit-code: '1'          # default — blocks push on CVEs
     secrets: inherit
     permissions:
       contents: read
       packages: write
       actions: read
 ```
+
+**Without scan (opt-out):**
+```yaml
+jobs:
+  build:
+    uses: duyhenryer/shared-workflows/.github/workflows/docker-build-go.yml@main
+    with:
+      image-name: my-service
+      push: true
+      scan-before-push: false
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+```
+
+> **Note**: `--load` (used for local scanning) only supports single-platform builds. If `platforms` is `linux/amd64` (default), this works. For multi-arch builds, the amd64 image is scanned locally; the multi-arch push only proceeds if the scan passes.
 
 ---
 
@@ -218,10 +247,10 @@ jobs:
 
 ## trivy-scan.yml
 
-**Purpose:** Docker image vulnerability scanning
+**Purpose:** Docker image vulnerability reporting (post-push)
 **Features:** Trivy scanner, SARIF upload to GitHub Security tab, step summary, optional Google Sheets reporting, structured outputs
 
-> Chain after any builder workflow (`docker-build-go.yml`, etc.) that pushes an image to GHCR. Place before `docker-sign.yml` to ensure only clean images are signed.
+> **Note**: This workflow is for **reporting only** — it is no longer the security gate. The security gate is now built into `docker-build-go.yml` and `docker-build-node.yml` via `scan-before-push`. Use `trivy-scan.yml` for detailed SARIF reporting and Google Sheets tracking after the image has been pushed.
 
 ### Inputs
 
@@ -470,28 +499,29 @@ jobs:
 
 ## Architecture
 
-The `docker-build-go.yml` is the **Go-specific builder**. Future stacks (`docker-build-node.yml`, `docker-build-python.yml`, etc.) follow the same output interface (`tags` + `digest`), sharing the downstream scan and sign workflows:
+The `docker-build-go.yml` is the **Go-specific builder** with integrated Trivy scanning. Future stacks (`docker-build-node.yml`, `docker-build-python.yml`, etc.) follow the same output interface (`tags` + `digest` + `scan-status`), sharing the downstream sign workflow:
 
 ```mermaid
 flowchart TD
-    subgraph builders ["Stack-specific Builders"]
-        GO["docker-build-go.yml"]
-        NODE["docker-build-node.yml (future)"]
+    subgraph builders ["Stack-specific Builders (scan-before-push)"]
+        GO["docker-build-go.yml<br/>(--load → Trivy → push)"]
+        NODE["docker-build-node.yml<br/>(--load → Trivy → push)"]
         PYTHON["docker-build-python.yml (future)"]
     end
     subgraph shared ["Shared Downstream"]
-        TRIVY["trivy-scan.yml"]
         SIGN["docker-sign.yml"]
+        TRIVY_RPT["trivy-scan.yml<br/>(SARIF reporting, optional)"]
     end
-    GO -->|"outputs: tags, digest"| TRIVY
-    NODE -->|"outputs: tags, digest"| TRIVY
-    PYTHON -->|"outputs: tags, digest"| TRIVY
-    TRIVY -->|"pass"| SIGN
+    GO -->|"outputs: tags, digest, scan-status"| SIGN
+    NODE -->|"outputs: tags, digest, scan-status"| SIGN
+    PYTHON -->|"outputs: tags, digest, scan-status"| SIGN
+    GO -.->|"optional"| TRIVY_RPT
+    NODE -.->|"optional"| TRIVY_RPT
 ```
 
 ### Overall CI Flow (Primary Diagram)
 
-Use this as the canonical high-level CI flow after adding `gitleaks.yml`.
+Canonical high-level CI flow with scan-before-push.
 
 ```mermaid
 flowchart TD
@@ -503,9 +533,9 @@ flowchart TD
     end
 
     subgraph buildOnly ["Push to main/dev only"]
-        BUILD["docker-build-go.yml"]
-        TRIVY["trivy-scan.yml"]
+        BUILD["docker-build-go.yml<br/>(--load → Trivy → push)"]
         SIGN["docker-sign.yml"]
+        TRIVY_RPT["trivy-scan.yml<br/>(optional report)"]
     end
 
     NOTIFY["status.yml"]
@@ -513,21 +543,21 @@ flowchart TD
     GOCHECK --> SONAR
     GITLEAKS --> SONAR
     SONAR --> BUILD
-    BUILD --> TRIVY
-    TRIVY --> SIGN
+    BUILD --> SIGN
+    BUILD -.-> TRIVY_RPT
 
     PRCHECKS --> NOTIFY
     GOCHECK --> NOTIFY
     GITLEAKS --> NOTIFY
     SONAR --> NOTIFY
     BUILD --> NOTIFY
-    TRIVY --> NOTIFY
     SIGN --> NOTIFY
+    TRIVY_RPT --> NOTIFY
 ```
 
 ### Detailed CI Flow: Pull Request
 
-On PR branches: run code quality + secret scanning + notifications. Docker jobs are **skipped** (`if: github.ref == 'refs/heads/main'`).
+On PR branches: run code quality + secret scanning + notifications. Docker jobs are **skipped**.
 
 ```mermaid
 flowchart TD
@@ -549,7 +579,7 @@ flowchart TD
 
 ### Detailed CI Flow: Push to main (merged)
 
-Full pipeline on main: build -> scan -> sign. If scan fails, sign is automatically skipped.
+Full pipeline on main: build (with integrated scan) -> sign. If pre-push scan fails, the image is never pushed and signing is automatically skipped.
 
 ```mermaid
 flowchart TD
@@ -558,11 +588,11 @@ flowchart TD
         GITLEAKS2["gitleaks.yml"]
         SONAR2["sonarqube.yml"]
 
-        BUILD["docker-build-go.yml"]
-        SCAN["trivy-scan.yml"]
+        BUILD["docker-build-go.yml<br/>(--load → Trivy → push)"]
         SIGN["docker-sign.yml"]
+        TRIVY_RPT["trivy-scan.yml<br/>(SARIF report, optional)"]
 
-        DBINIT["docker-build-go.yml (migration)"]
+        DBINIT["docker-build-go.yml (migration)<br/>(--load → Trivy → push)"]
 
         NOTIFY2["status.yml"]
 
@@ -570,16 +600,19 @@ flowchart TD
         GITLEAKS2 --> SONAR2
         SONAR2 --> BUILD
         SONAR2 --> DBINIT
-        BUILD -->|"outputs: tags, digest"| SCAN
-        SCAN -->|"success"| SIGN
-        SCAN -.->|"fail"| SIGN_SKIP["sign SKIPPED"]
+        BUILD -->|"scan pass → pushed"| SIGN
+        BUILD -.->|"scan fail"| BUILD_FAIL["Image NOT pushed"]
+        BUILD -.->|"optional"| TRIVY_RPT
 
         BUILD --> NOTIFY2
-        SCAN --> NOTIFY2
         SIGN --> NOTIFY2
+        TRIVY_RPT --> NOTIFY2
         GITLEAKS2 --> NOTIFY2
         DBINIT --> NOTIFY2
     end
+
+    style BUILD fill:#3b82f6,color:#fff
+    style BUILD_FAIL fill:#ef4444,color:#fff
 ```
 
 ---
@@ -646,9 +679,9 @@ jobs:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 ```
 
-### Docker Build Pipeline (build -> scan -> sign)
+### Docker Build Pipeline (build with scan -> sign)
 
-Service repos chain the individual workflows explicitly. Each job passes outputs to the next via `needs`:
+Service repos call the builder workflow which handles scan-before-push internally. Each job passes outputs to the next via `needs`:
 
 ```yaml
 name: Docker Build
@@ -666,26 +699,28 @@ permissions:
   security-events: write
 
 jobs:
-  # Step 1: Build & push
+  # Step 1: Build, scan, and push (scan is integrated)
   build:
     uses: duyhenryer/shared-workflows/.github/workflows/docker-build-go.yml@main
     with:
       image-name: my-service
       push: true
+      # scan-before-push: true  # default — scans before pushing
     secrets: inherit
     permissions:
       contents: read
       packages: write
       actions: read
 
-  # Step 2: Vulnerability scan (uses digest from build)
-  scan:
+  # Step 2 (optional): Detailed vulnerability report (SARIF + Google Sheets)
+  trivy-report:
     needs: [build]
+    if: needs.build.outputs.scan-status == 'pass'
     uses: duyhenryer/shared-workflows/.github/workflows/trivy-scan.yml@main
     with:
       image-ref: ghcr.io/${{ github.repository }}/my-service@${{ needs.build.outputs.digest }}
-      severity: 'CRITICAL,HIGH'
-      exit-code: '1'
+      severity: 'CRITICAL,HIGH,MEDIUM'
+      exit-code: '0'         # non-blocking (reporting only)
       ignore-unfixed: true
     secrets: inherit
     permissions:
@@ -693,9 +728,9 @@ jobs:
       packages: read
       security-events: write
 
-  # Step 3: Sign (uses tags + digest from build; auto-skipped if scan fails)
+  # Step 3: Sign (auto-skipped if build fails due to scan)
   sign:
-    needs: [build, scan]
+    needs: [build]
     uses: duyhenryer/shared-workflows/.github/workflows/docker-sign.yml@main
     with:
       tags: ${{ needs.build.outputs.tags }}
@@ -707,7 +742,7 @@ jobs:
       id-token: write
 
   notify:
-    needs: [build, scan, sign]
+    needs: [build, trivy-report, sign]
     if: always()
     uses: duyhenryer/shared-workflows/.github/workflows/status.yml@main
     with:
@@ -716,7 +751,7 @@ jobs:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 ```
 
-> **How it works:** `sign` depends on both `build` and `scan`. If `scan` fails, GitHub automatically skips `sign` -- no `if:` condition needed. To scan without blocking sign, set `exit-code: '0'`.
+> **How it works:** The builder workflow handles `--load` → Trivy scan → push internally. If the scan fails, the image is never pushed and the job fails. `sign` depends on `build` — if build fails, sign is auto-skipped. `trivy-report` is optional and non-blocking (for SARIF + Google Sheets reporting).
 
 ---
 
@@ -845,19 +880,19 @@ with:
   fail-on-quality-gate: false
 ```
 
-### "Trivy scan blocking image signing"
+### "Trivy scan blocking image push"
 
-**Solution:** If you want to scan without blocking the sign phase, set `exit-code` to `'0'` in your `trivy-scan.yml` call:
+**Solution:** If you want to scan without blocking the push, set `scan-exit-code` to `'0'` in your `docker-build-go.yml` call:
 ```yaml
-  scan:
-    needs: [build]
-    uses: duyhenryer/shared-workflows/.github/workflows/trivy-scan.yml@main
+  build:
+    uses: duyhenryer/shared-workflows/.github/workflows/docker-build-go.yml@main
     with:
-      image-ref: ghcr.io/${{ github.repository }}/my-service@${{ needs.build.outputs.digest }}
-      exit-code: '0'  # Warn only, don't block signing
+      image-name: my-service
+      push: true
+      scan-exit-code: '0'  # Warn only, don't block push
 ```
 
-Or to skip scanning entirely, simply remove the `scan` job and have `sign` depend only on `build`.
+Or to skip scanning entirely, set `scan-before-push: false`.
 
 ---
 


### PR DESCRIPTION
## Summary by Sourcery

Integrate pre-push vulnerability scanning into the reusable Docker build workflows and update documentation to reflect scan-before-push as the new security gate.

New Features:
- Add a Node-specific Docker build workflow that supports Trivy scan-before-push and exposes image tags, digest, and scan status outputs.
- Extend the Go Docker build workflow with configurable Trivy pre-push scanning and a scan-status output for downstream jobs.

Enhancements:
- Adjust Docker build job logic to separate local build, scan, push, and build-only paths while preserving multi-platform support, caching, provenance, and SBOM options.
- Improve build summaries to report whether an image was pushed and the result of the pre-push scan.
- Update USAGE and README documents to describe the integrated scan-before-push behavior, new inputs and outputs, and revised CI architecture and examples that treat trivy-scan as an optional reporting step.

Documentation:
- Revise USAGE.md to document scan-before-push settings, scan-status output, and the new CI architecture where builders enforce security gates and trivy-scan is used for reporting only.
- Update README.md workflow listings and pipeline examples to include the Node builder, highlight integrated Trivy scanning, and show optional post-push reporting flows.