### PR TITLE
Harden workflows and fix post-transfer references

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Global owners — requested for review on every PR
-* @duyhenryer @duynebot
+* @duynhne @duynebot
 
 # Protect this file itself
-/.github/CODEOWNERS @duyhenryer
+/.github/CODEOWNERS @duynhne

--- a/.github/actions/slack-notification/action.yml
+++ b/.github/actions/slack-notification/action.yml
@@ -43,7 +43,7 @@ runs:
     - name: Send standalone CI status
       id: slack-standalone
       if: inputs.thread_ts == ''
-      uses: slackapi/slack-github-action@v3.0.1
+      uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
       with:
         method: chat.${{ inputs.update_ts && 'update' || 'postMessage' }}
         token: ${{ inputs.slack_bot_token }}
@@ -96,7 +96,7 @@ runs:
     - name: Reply CI status in thread
       id: slack-reply
       if: inputs.thread_ts != ''
-      uses: slackapi/slack-github-action@v3.0.1
+      uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
       with:
         method: chat.postMessage
         token: ${{ inputs.slack_bot_token }}

--- a/.github/workflows/docker-build-go.yml
+++ b/.github/workflows/docker-build-go.yml
@@ -107,18 +107,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up QEMU
         if: inputs.platforms != 'linux/amd64'
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Log in to GitHub Container Registry
         if: inputs.push
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -126,7 +126,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
           images: ghcr.io/${{ github.repository }}/${{ inputs.image-name }}
           tags: |
@@ -142,7 +142,7 @@ jobs:
       - name: Build image (local)
         id: build-local
         if: inputs.push && inputs.scan-before-push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}
@@ -160,7 +160,7 @@ jobs:
       - name: Trivy pre-push scan
         id: trivy
         if: inputs.push && inputs.scan-before-push
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
           format: 'table'
@@ -191,7 +191,7 @@ jobs:
             !inputs.scan-before-push ||
             steps.trivy.outcome == 'success'
           )
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}
@@ -211,7 +211,7 @@ jobs:
       - name: Build and push (no pre-scan)
         id: build-no-scan
         if: inputs.push && !inputs.scan-before-push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}
@@ -231,7 +231,7 @@ jobs:
       - name: Build image (no push)
         id: build-only
         if: '!inputs.push && !inputs.scan-before-push'
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}

--- a/.github/workflows/docker-build-node.yml
+++ b/.github/workflows/docker-build-node.yml
@@ -107,18 +107,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up QEMU
         if: inputs.platforms != 'linux/amd64'
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Log in to GitHub Container Registry
         if: inputs.push
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -126,7 +126,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
           images: ghcr.io/${{ github.repository }}/${{ inputs.image-name }}
           tags: |
@@ -142,7 +142,7 @@ jobs:
       - name: Build image (local)
         id: build-local
         if: inputs.push && inputs.scan-before-push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}
@@ -160,7 +160,7 @@ jobs:
       - name: Trivy pre-push scan
         id: trivy
         if: inputs.push && inputs.scan-before-push
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
           format: 'table'
@@ -191,7 +191,7 @@ jobs:
             !inputs.scan-before-push ||
             steps.trivy.outcome == 'success'
           )
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}
@@ -211,7 +211,7 @@ jobs:
       - name: Build and push (no pre-scan)
         id: build-no-scan
         if: inputs.push && !inputs.scan-before-push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}
@@ -231,7 +231,7 @@ jobs:
       - name: Build image (no push)
         id: build-only
         if: '!inputs.push && !inputs.scan-before-push'
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}

--- a/.github/workflows/docker-sign.yml
+++ b/.github/workflows/docker-sign.yml
@@ -31,10 +31,10 @@ jobs:
 
     steps:
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -52,21 +52,13 @@ jobs:
 
     steps:
       - name: Checkout caller repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
-      - name: Checkout shared-workflows (for composite action)
-        uses: actions/checkout@v6
-        with:
-          repository: duyhenryer/shared-workflows
-          path: .shared-workflows
-          sparse-checkout: |
-            .github/actions/gitleaks
-
       - name: Run Gitleaks
         id: gitleaks
-        uses: ./.shared-workflows/.github/actions/gitleaks
+        uses: duynhlab/gha-workflows/.github/actions/gitleaks@main
         with:
           version: ${{ inputs.gitleaks-version }}
           config-path: ${{ inputs.config-path }}
@@ -74,7 +66,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Security tab
         if: always()
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: ${{ steps.gitleaks.outputs.sarif }}
         continue-on-error: true

--- a/.github/workflows/go-check.yml
+++ b/.github/workflows/go-check.yml
@@ -54,10 +54,10 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         if: ${{ inputs.setup-go }}
         with:
           go-version-file: ${{ inputs.gomod-path }}
@@ -69,7 +69,7 @@ jobs:
         run: ${{ inputs.command-test }}
 
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: success()
         with:
           name: coverage-report
@@ -84,10 +84,10 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Go (stable)
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         if: ${{ inputs.setup-go }}
         with:
           go-version: 'stable'
@@ -106,9 +106,9 @@ jobs:
     if: github.event_name == 'pull_request' && inputs.lint
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Setup go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: ${{ inputs.gomod-path }}
           cache: false
@@ -122,4 +122,4 @@ jobs:
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${{ inputs.lint-version }}
 
       - name: Lint check
-        run: golangci-lint run --timeout=${{ inputs.lint-timeout }} --config=${{ inputs.lint-path }}
+        run: golangci-lint run --timeout="${{ inputs.lint-timeout }}" --config="${{ inputs.lint-path }}"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -28,10 +28,14 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     steps:
     - name: Validate Source Branch
+      env:
+        HEAD_REF: ${{ github.head_ref }}
       run: |
-        # Allow standard gitflow/trunk-based prefixes
-        if [[ ! ${{ github.head_ref }} =~ ^(feature|feat|fix|bugfix|hotfix|release|chore|docs|refactor|dependabot|ci|renovate|build)\/ ]]; then
-          echo "Error: Source branch '${{ github.head_ref }}' does not match allowed patterns (feat/*, fix/*, chore/*, etc.)"
+        # Allow standard gitflow/trunk-based prefixes.
+        # HEAD_REF is passed via env (not interpolated into the script) to avoid
+        # shell injection from an attacker-controlled branch name.
+        if [[ ! "$HEAD_REF" =~ ^(feature|feat|fix|bugfix|hotfix|release|chore|docs|refactor|dependabot|ci|renovate|build)\/ ]]; then
+          echo "Error: Source branch '$HEAD_REF' does not match allowed patterns (feat/*, fix/*, chore/*, etc.)"
           echo "Create a new branch with a valid prefix and open a new PR."
           exit 1
         fi
@@ -42,7 +46,7 @@ jobs:
       thread_ts: ${{ steps.slack-notify.outputs.ts }}
     steps:
       - name: Checkout CODEOWNERS file
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           sparse-checkout: |
             .github/CODEOWNERS
@@ -70,7 +74,7 @@ jobs:
       ## Notify the PR details to codeowners on slack
       - name: Notify PR Event
         id: slack-notify
-        uses: slackapi/slack-github-action@v3.0.3
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0  # Full history for proper blame information
 

--- a/.github/workflows/status.yml
+++ b/.github/workflows/status.yml
@@ -52,7 +52,7 @@ jobs:
       workflow_status_rows_json: ${{ steps.fetch-workflow-status.outputs.workflow_status_rows_json }}
       jobs_status_rows_json: ${{ steps.fetch-workflow-status.outputs.jobs_status_rows_json }}
     steps:
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         id: fetch-workflow-status
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -158,7 +158,7 @@ jobs:
       - workflow-status
     steps:
       - name: Slack channel
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         id: slack-channel
         with:
           script: |
@@ -168,17 +168,9 @@ jobs:
             core.setOutput('slack_channel_id', slack_channel_id);
 
 
-      - name: Checkout shared-workflows (for composite action)
-        uses: actions/checkout@v6
-        with:
-          repository: duyhenryer/shared-workflows
-          path: .shared-workflows
-          sparse-checkout: |
-            .github/actions/slack-notification
-
       - name: Slack CI Notification
         if: ${{ steps.slack-channel.outputs.slack_channel_id != '' }}
-        uses: ./.shared-workflows/.github/actions/slack-notification
+        uses: duynhlab/gha-workflows/.github/actions/slack-notification@main
         with:
           channel_id: ${{ steps.slack-channel.outputs.slack_channel_id }}
           status: ${{ needs.workflow-status.outputs.status }}
@@ -188,7 +180,7 @@ jobs:
       # --- Google Sheets Reporting ---
       - name: Append workflow status to Google Sheet
         if: ${{ always() && inputs.gsheet_spreadsheet_id != '' }}
-        uses: jroehl/gsheet.action@v2.1.1
+        uses: jroehl/gsheet.action@ec5aa4154b217321530a31d5b2555e107b2e2b48 # v2.1.1
         with:
           spreadsheetId: ${{ inputs.gsheet_spreadsheet_id }}
           commands: |
@@ -208,7 +200,7 @@ jobs:
 
       - name: Append jobs status to Google Sheet
         if: ${{ always() && inputs.gsheet_spreadsheet_id != '' }}
-        uses: jroehl/gsheet.action@v2.1.1
+        uses: jroehl/gsheet.action@ec5aa4154b217321530a31d5b2555e107b2e2b48 # v2.1.1
         with:
           spreadsheetId: ${{ inputs.gsheet_spreadsheet_id }}
           commands: |

--- a/.github/workflows/tf-lint.yml
+++ b/.github/workflows/tf-lint.yml
@@ -26,7 +26,7 @@ jobs:
 
       steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
@@ -42,10 +42,10 @@ jobs:
 
       steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Cache plugin dir
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.tflint.d/plugins
           key: tflint-${{ hashFiles('.tflint.hcl') }}

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -86,7 +86,7 @@ jobs:
 
     steps:
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -94,7 +94,7 @@ jobs:
 
       # Step 1: Scan with JSON output (always succeed so we can parse results)
       - name: Trivy scan (JSON)
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ inputs.image-ref }}
           format: 'json'
@@ -176,7 +176,7 @@ jobs:
 
       # Step 3: Scan with SARIF output for GitHub Security tab
       - name: Trivy scan (SARIF)
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ inputs.image-ref }}
           format: 'sarif'
@@ -189,7 +189,7 @@ jobs:
 
       # Step 4: Upload SARIF to GitHub Security tab
       - name: Upload Trivy SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
@@ -197,7 +197,7 @@ jobs:
       # Step 5: Google Sheets reporting (optional)
       - name: Append security scan to Google Sheet
         if: ${{ always() && inputs.gsheet_spreadsheet_id != '' }}
-        uses: jroehl/gsheet.action@v2.1.1
+        uses: jroehl/gsheet.action@ec5aa4154b217321530a31d5b2555e107b2e2b48 # v2.1.1
         with:
           spreadsheetId: ${{ inputs.gsheet_spreadsheet_id }}
           commands: |

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ on:
 
 jobs:
   check:
-    uses: duyhenryer/shared-workflows/.github/workflows/go-check.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/go-check.yml@main
     with:
       command-test: 'go test ./...'
       lint: true
@@ -50,7 +50,7 @@ jobs:
 ```yaml
 jobs:
   go-check:
-    uses: duyhenryer/shared-workflows/.github/workflows/go-check.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/go-check.yml@main
     with:
       command-test: 'go test ./...'
       lint: true
@@ -61,7 +61,7 @@ jobs:
 ```yaml
 jobs:
   gitleaks:
-    uses: duyhenryer/shared-workflows/.github/workflows/gitleaks.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/gitleaks.yml@main
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     with:
       config-path: '.gitleaks.toml'  # optional
@@ -74,7 +74,7 @@ jobs:
 ```yaml
 jobs:
   build:
-    uses: duyhenryer/shared-workflows/.github/workflows/docker-build-go.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/docker-build-go.yml@main
     with:
       image-name: my-service
       push: true
@@ -89,7 +89,7 @@ jobs:
 
   sign:
     needs: [build]
-    uses: duyhenryer/shared-workflows/.github/workflows/docker-sign.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/docker-sign.yml@main
     with:
       tags: ${{ needs.build.outputs.tags }}
       digest: ${{ needs.build.outputs.digest }}
@@ -104,7 +104,7 @@ jobs:
 ```yaml
 jobs:
   build:
-    uses: duyhenryer/shared-workflows/.github/workflows/docker-build-go.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/docker-build-go.yml@main
     with:
       image-name: my-service
       push: true
@@ -118,7 +118,7 @@ jobs:
   trivy-report:
     needs: [build]
     if: needs.build.outputs.scan-status == 'pass'
-    uses: duyhenryer/shared-workflows/.github/workflows/trivy-scan.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/trivy-scan.yml@main
     with:
       image-ref: ghcr.io/${{ github.repository }}/my-service@${{ needs.build.outputs.digest }}
       severity: 'CRITICAL,HIGH,MEDIUM'
@@ -132,7 +132,7 @@ jobs:
 
   sign:
     needs: [build]
-    uses: duyhenryer/shared-workflows/.github/workflows/docker-sign.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/docker-sign.yml@main
     with:
       tags: ${{ needs.build.outputs.tags }}
       digest: ${{ needs.build.outputs.digest }}
@@ -147,7 +147,7 @@ jobs:
 ```yaml
 jobs:
   terraform-check:
-    uses: duyhenryer/shared-workflows/.github/workflows/tf-lint.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/tf-lint.yml@main
     with:
       tflint_minimum_failure_severity: 'error'
 ```
@@ -156,7 +156,7 @@ jobs:
 ```yaml
 jobs:
   notify-status:
-    uses: duyhenryer/shared-workflows/.github/workflows/status.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/status.yml@main
     with:
       slack_channel_id: "#dev-notifications"
     secrets: inherit

--- a/USAGE.md
+++ b/USAGE.md
@@ -37,7 +37,7 @@ Detailed documentation for all available workflows with inputs, outputs, and exa
 jobs:
   pr-checks:
     if: github.event_name == 'pull_request'
-    uses: duyhenryer/shared-workflows/.github/workflows/pr-checks.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/pr-checks.yml@main
     with:
       slack_channel_id: "C0AD82A9A74"
     secrets:
@@ -72,7 +72,7 @@ jobs:
 ```yaml
 jobs:
   go-check:
-    uses: duyhenryer/shared-workflows/.github/workflows/go-check.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/go-check.yml@main
     with:
       command-test: 'go test ./...'
     secrets: inherit
@@ -82,7 +82,7 @@ jobs:
 ```yaml
 jobs:
   go-check:
-    uses: duyhenryer/shared-workflows/.github/workflows/go-check.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/go-check.yml@main
     with:
       command-test: 'go test -race -coverprofile=coverage.out -covermode=atomic ./...'
       lint: true
@@ -125,7 +125,7 @@ jobs:
 jobs:
   gitleaks:
     if: "!startsWith(github.ref, 'refs/tags/')"
-    uses: duyhenryer/shared-workflows/.github/workflows/gitleaks.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/gitleaks.yml@main
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     with:
       config-path: '.gitleaks.toml' # optional
@@ -177,7 +177,7 @@ jobs:
 ```yaml
 jobs:
   build:
-    uses: duyhenryer/shared-workflows/.github/workflows/docker-build-go.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/docker-build-go.yml@main
     with:
       image-name: my-service
       push: true
@@ -195,7 +195,7 @@ jobs:
 ```yaml
 jobs:
   build:
-    uses: duyhenryer/shared-workflows/.github/workflows/docker-build-go.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/docker-build-go.yml@main
     with:
       image-name: my-service
       push: true
@@ -232,7 +232,7 @@ jobs:
 jobs:
   sign:
     needs: [build]
-    uses: duyhenryer/shared-workflows/.github/workflows/docker-sign.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/docker-sign.yml@main
     with:
       tags: ${{ needs.build.outputs.tags }}
       digest: ${{ needs.build.outputs.digest }}
@@ -291,7 +291,7 @@ jobs:
 
   scan:
     needs: [build]
-    uses: duyhenryer/shared-workflows/.github/workflows/trivy-scan.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/trivy-scan.yml@main
     with:
       image-ref: ghcr.io/${{ github.repository }}/my-app@${{ needs.build.outputs.digest }}
       severity: 'CRITICAL,HIGH'
@@ -307,7 +307,7 @@ jobs:
 ```yaml
 jobs:
   scan:
-    uses: duyhenryer/shared-workflows/.github/workflows/trivy-scan.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/trivy-scan.yml@main
     with:
       image-ref: ghcr.io/${{ github.repository }}/my-app@sha256:abc123...
       gsheet_spreadsheet_id: "1AbC...xYz"
@@ -356,14 +356,14 @@ jobs:
 ```yaml
 jobs:
   go-check:
-    uses: duyhenryer/shared-workflows/.github/workflows/go-check.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/go-check.yml@main
     with:
       command-test: 'go test -race -coverprofile=coverage.out -covermode=atomic ./...'
     secrets: inherit
 
   sonar:
     needs: [go-check]
-    uses: duyhenryer/shared-workflows/.github/workflows/sonarqube.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/sonarqube.yml@main
     with:
       project-key: my-org_my-project
       organization: my-org
@@ -391,7 +391,7 @@ jobs:
 ```yaml
 jobs:
   terraform-check:
-    uses: duyhenryer/shared-workflows/.github/workflows/tf-lint.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/tf-lint.yml@main
     with:
       tflint_minimum_failure_severity: 'error'
 ```
@@ -429,7 +429,7 @@ jobs:
   notify:
     needs: [build, test]
     if: always()
-    uses: duyhenryer/shared-workflows/.github/workflows/status.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/status.yml@main
     with:
       slack_channel_id: "C0AD82A9A74"
     secrets:
@@ -441,7 +441,7 @@ jobs:
 jobs:
   pr-checks:
     if: github.event_name == 'pull_request'
-    uses: duyhenryer/shared-workflows/.github/workflows/pr-checks.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/pr-checks.yml@main
     with:
       slack_channel_id: "C0AD82A9A74"
     secrets:
@@ -452,7 +452,7 @@ jobs:
   notify:
     needs: [pr-checks, build, test]
     if: always()
-    uses: duyhenryer/shared-workflows/.github/workflows/status.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/status.yml@main
     with:
       slack_channel_id: "C0AD82A9A74"
       slack_thread_ts: ${{ needs.pr-checks.outputs.slack_thread_ts }}
@@ -634,7 +634,7 @@ jobs:
   # PR Validation
   pr-checks:
     if: github.event_name == 'pull_request'
-    uses: duyhenryer/shared-workflows/.github/workflows/pr-checks.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/pr-checks.yml@main
     with:
       slack_channel_id: "C0AD82A9A74"
     secrets:
@@ -642,7 +642,7 @@ jobs:
 
   # Go quality checks
   go-check:
-    uses: duyhenryer/shared-workflows/.github/workflows/go-check.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/go-check.yml@main
     with:
       command-test: 'go test -race -coverprofile=coverage.out -covermode=atomic ./...'
       lint: true
@@ -651,7 +651,7 @@ jobs:
   # Secret scanning
   gitleaks:
     if: "!startsWith(github.ref, 'refs/tags/')"
-    uses: duyhenryer/shared-workflows/.github/workflows/gitleaks.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/gitleaks.yml@main
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     permissions:
       contents: read
@@ -660,7 +660,7 @@ jobs:
   # SonarCloud analysis
   sonar:
     needs: [go-check, gitleaks]
-    uses: duyhenryer/shared-workflows/.github/workflows/sonarqube.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/sonarqube.yml@main
     with:
       project-key: my-org_my-project
       organization: my-org
@@ -671,7 +671,7 @@ jobs:
   notify:
     needs: [pr-checks, go-check, gitleaks, sonar]
     if: always()
-    uses: duyhenryer/shared-workflows/.github/workflows/status.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/status.yml@main
     with:
       slack_channel_id: "C0AD82A9A74"
       slack_thread_ts: ${{ needs.pr-checks.outputs.slack_thread_ts }}
@@ -701,7 +701,7 @@ permissions:
 jobs:
   # Step 1: Build, scan, and push (scan is integrated)
   build:
-    uses: duyhenryer/shared-workflows/.github/workflows/docker-build-go.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/docker-build-go.yml@main
     with:
       image-name: my-service
       push: true
@@ -716,7 +716,7 @@ jobs:
   trivy-report:
     needs: [build]
     if: needs.build.outputs.scan-status == 'pass'
-    uses: duyhenryer/shared-workflows/.github/workflows/trivy-scan.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/trivy-scan.yml@main
     with:
       image-ref: ghcr.io/${{ github.repository }}/my-service@${{ needs.build.outputs.digest }}
       severity: 'CRITICAL,HIGH,MEDIUM'
@@ -731,7 +731,7 @@ jobs:
   # Step 3: Sign (auto-skipped if build fails due to scan)
   sign:
     needs: [build]
-    uses: duyhenryer/shared-workflows/.github/workflows/docker-sign.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/docker-sign.yml@main
     with:
       tags: ${{ needs.build.outputs.tags }}
       digest: ${{ needs.build.outputs.digest }}
@@ -744,7 +744,7 @@ jobs:
   notify:
     needs: [build, trivy-report, sign]
     if: always()
-    uses: duyhenryer/shared-workflows/.github/workflows/status.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/status.yml@main
     with:
       slack_channel_id: "C0AD82A9A74"
     secrets:
@@ -783,7 +783,7 @@ Set these in your repository settings (Settings → Secrets and variables → Ac
 
 ### How `pr-checks.yml` uses CODEOWNERS
 
-The `pr-checks.yml` workflow automatically extracts global code owners from the caller repo's CODEOWNERS file and tags them in the Slack PR notification (e.g. `cc @duyhenryer @duynebot`).
+The `pr-checks.yml` workflow automatically extracts global code owners from the caller repo's CODEOWNERS file and tags them in the Slack PR notification (e.g. `cc @duynhne @duynebot`).
 
 **Discovery order** (matches [GitHub's precedence](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-location)):
 
@@ -801,7 +801,7 @@ Each line is a **file pattern** followed by one or more **owners** (`@username` 
 
 ```gitignore
 # Global owners -- requested for review on every PR
-* @duyhenryer @duynebot
+* @duynhne @duynebot
 
 # Team-based ownership
 *.go        @duynhne/backend-team
@@ -811,10 +811,10 @@ Each line is a **file pattern** followed by one or more **owners** (`@username` 
 # Directory-specific
 /cmd/       @duynhne/backend-team
 /terraform/ @duynhne/infra-team
-/docs/      @duyhenryer
+/docs/      @duynhne
 
 # Protect the CODEOWNERS file itself
-/.github/CODEOWNERS @duyhenryer
+/.github/CODEOWNERS @duynhne
 ```
 
 ### Key rules
@@ -885,7 +885,7 @@ with:
 **Solution:** If you want to scan without blocking the push, set `scan-exit-code` to `'0'` in your `docker-build-go.yml` call:
 ```yaml
   build:
-    uses: duyhenryer/shared-workflows/.github/workflows/docker-build-go.yml@main
+    uses: duynhlab/gha-workflows/.github/workflows/docker-build-go.yml@main
     with:
       image-name: my-service
       push: true
@@ -910,7 +910,7 @@ Or to skip scanning entirely, set `scan-before-push: false`.
 
 <div align="center">
 
-**Need help?** [Open an issue](https://github.com/duyhenryer/shared-workflows/issues)
+**Need help?** [Open an issue](https://github.com/duynhlab/gha-workflows/issues)
 
 [Back to Top](#workflow-usage-guide)
 


### PR DESCRIPTION
Post-transfer cleanup + supply-chain hardening (`duyhenryer/shared-workflows` → `duynhlab/gha-workflows`).

## Critical — broken internal self-references
`status.yml` and `gitleaks.yml` checked out `duyhenryer/shared-workflows` into `.shared-workflows/` to load a composite action. That breaks after the transfer. (A reusable workflow runs in the **caller's** workspace, so it genuinely cannot use a `./.github/actions/...` path from its own repo — the earlier "just use the local action" idea would not work.) Fixed by referencing the action via its **remote path** `duynhlab/gha-workflows/.github/actions/<name>@main` and dropping the sparse-checkout entirely.

## Supply-chain — SHA-pin all third-party actions
Pinned 16 action references to full commit SHAs (each with a `# vX` comment) across the workflows + the slack composite action. The handful already SHA-pinned (sonar, terraform, download-artifact, tflint) are untouched. Per GitHub's hardening guidance.

## Other hardening / cleanup
- **CODEOWNERS**: `@duyhenryer` → `@duynhne` (old personal account → maintainer; `duynhlab` is the org, `duynhne` the user). **Please confirm this is the handle you want.**
- **`pr-checks.yml`**: `github.head_ref` now passed via `env:` instead of interpolated into the inline branch-name check — script-injection hardening; also clears the only `actionlint` warning.
- Quoted `golangci-lint --config/--timeout` inputs.
- `README.md` + `USAGE.md` examples → `duynhlab/gha-workflows`.

## Deliberately NOT changed (verified false positives during review)
- `go-check.yml` Go module cache: the test jobs already cache via `setup-go`'s default; the lint job sets `cache: false` **on purpose** (documented golangci-lint typecheck-bug workaround) — adding caching would reintroduce the bug.
- `sonarqube.yml` `go-version: '1.25'` input: it is **declared but never used** (no `setup-go` step in that job), so it can't cause a failure — left as-is (flagged as dead config to clean up later).

## Versioning
Consumers stay on `@main` this pass (per decision); a `@v1` major-tag policy is documented as the next step.

## Verification
`actionlint .github/workflows/*.yml` → clean (exit 0); no `duyhenryer`/`shared-workflows` strings remain anywhere in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)