### PR TITLE
CODEOWNERS: own with both @duynhne and @duyhenryer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Global owners — requested for review on every PR
-* @duynhne @duynebot
+* @duynhne @duyhenryer @duynebot
 
 # Protect this file itself
-/.github/CODEOWNERS @duynhne
+/.github/CODEOWNERS @duynhne @duyhenryer

--- a/USAGE.md
+++ b/USAGE.md
@@ -783,7 +783,7 @@ Set these in your repository settings (Settings → Secrets and variables → Ac
 
 ### How `pr-checks.yml` uses CODEOWNERS
 
-The `pr-checks.yml` workflow automatically extracts global code owners from the caller repo's CODEOWNERS file and tags them in the Slack PR notification (e.g. `cc @duynhne @duynebot`).
+The `pr-checks.yml` workflow automatically extracts global code owners from the caller repo's CODEOWNERS file and tags them in the Slack PR notification (e.g. `cc @duynhne @duyhenryer @duynebot`).
 
 **Discovery order** (matches [GitHub's precedence](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-location)):
 
@@ -801,7 +801,7 @@ Each line is a **file pattern** followed by one or more **owners** (`@username` 
 
 ```gitignore
 # Global owners -- requested for review on every PR
-* @duynhne @duynebot
+* @duynhne @duyhenryer @duynebot
 
 # Team-based ownership
 *.go        @duynhne/backend-team


### PR DESCRIPTION
Per maintainer decision: keep **both** human owners (`@duynhne` **and** `@duyhenryer`), plus `@duynebot`, as global code owners after the org transfer.

#54 merged with only `@duynhne` — this restores `@duyhenryer` alongside it, in both `.github/CODEOWNERS` and the matching `USAGE.md` examples.

> Note: for the entry to be honored, `@duyhenryer` must have write access to `duynhlab/gha-workflows` (org member/collaborator). Otherwise GitHub silently ignores that owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)