### PR TITLE
Add reusable GoReleaser binary-release workflow

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,0 +1,86 @@
+name: GoReleaser Binary Release
+
+# Reusable workflow: builds a Go service's release binary with GoReleaser and
+# publishes it to a GitHub Release on a `v*` tag. The artifacts deliberately match
+# the duynhlab/packages build-local contract so packages can consume the release
+# instead of compiling from source:
+#   - <repo>-<version>-linux-amd64.tar.gz   (containing bin/<repo> + LICENSE/README)
+#   - <tarball>.sha256                       (per-file checksum)
+#   - build-info.env                         (SERVICE/VERSION/GIT_SHA/SCHEMA_VERSION/...)
+# The .goreleaser.yaml lives in the calling repo; this workflow generates
+# build-info.env (so the logic stays in one place) and runs GoReleaser.
+
+on:
+  workflow_call:
+    inputs:
+      go-version:
+        description: 'Go version for the build'
+        required: false
+        type: string
+        default: '1.26'
+      goreleaser-version:
+        # NB: this constrains the GoReleaser *CLI* (v2), which is independent of the
+        # goreleaser-action major (v7) pinned in the Run step below — don't "align" them.
+        description: 'GoReleaser CLI version constraint (passed to goreleaser-action)'
+        required: false
+        type: string
+        default: '~> v2'
+
+permissions:
+  contents: write # create the GitHub Release + upload assets
+
+concurrency:
+  group: goreleaser-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0 # full history + tags for the changelog/version
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: ${{ inputs.go-version }}
+          cache: true
+
+      - name: Generate build-info.env
+        shell: bash
+        # Mirrors packages/scripts/build-local.sh so packages can read the same
+        # sidecar. SCHEMA_VERSION = highest embedded migration (audit only).
+        run: |
+          set -euo pipefail
+          service="${GITHUB_REPOSITORY##*/}"; service="${service%-service}"
+          version="${GITHUB_REF_NAME#v}"
+          git_sha="$(git rev-parse --short HEAD)"
+          schema_version=0
+          if compgen -G "db/migrations/sql/*.up.sql" >/dev/null; then
+            schema_version="$(for f in db/migrations/sql/*.up.sql; do
+              basename "$f" | cut -d_ -f1
+            done | sed 's/^0*//' | sort -n | tail -1)"
+            schema_version="${schema_version:-0}"
+          fi
+          cat > build-info.env <<EOF
+          SERVICE=${service}
+          TYPE=backend
+          VERSION=${version}
+          GIT_SHA=${git_sha}
+          GOOS=linux
+          GOARCH=amd64
+          SCHEMA_VERSION=${schema_version}
+          BUILT_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          SOURCE=github-release
+          EOF
+          echo "::group::build-info.env"; cat build-info.env; echo "::endgroup::"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
+        with:
+          version: ${{ inputs.goreleaser-version }}
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ jobs:
 | **[docker-build-node.yml](.github/workflows/docker-build-node.yml)** | Docker build (Node) | **Scan-before-push**, multi-platform, caching, provenance, outputs `tags` + `digest` + `scan-status` |
 | **[trivy-scan.yml](.github/workflows/trivy-scan.yml)** | Image vulnerability report | Trivy post-push scan, SARIF, Google Sheets reporting |
 | **[docker-sign.yml](.github/workflows/docker-sign.yml)** | Cosign image signing | Keyless OIDC signing |
+| **[goreleaser.yml](.github/workflows/goreleaser.yml)** | Go binary release (on `v*` tags) | GoReleaser → GitHub Release; tarball + `.sha256` + `build-info.env` matching the `packages` contract |
 | **[sonarqube.yml](.github/workflows/sonarqube.yml)** | SonarCloud analysis | Go coverage, Quality Gate |
 | **[tf-lint.yml](.github/workflows/tf-lint.yml)** | Terraform validation | Format check, TFLint analysis |
 | **[status.yml](.github/workflows/status.yml)** | Build notifications | Slack, Google Sheets, job summaries |


### PR DESCRIPTION
## What

A new reusable (`workflow_call`) workflow **`goreleaser.yml`** that builds a Go service's release **binary** with GoReleaser and publishes it to a **GitHub Release on a `v*` tag**.

## Why

The `packages` mega-RPM currently compiles every service from source. This makes each service publish a release binary in a format `packages` can **download** instead — matching `packages/scripts/build-local.sh` exactly:
- `<repo>-<version>-linux-amd64.tar.gz` (containing `bin/<repo>`),
- `<tarball>.sha256` (per-file),
- `build-info.env` (`SERVICE/TYPE/VERSION/GIT_SHA/GOOS/GOARCH/SCHEMA_VERSION/BUILT_AT/SOURCE`).

The workflow generates `build-info.env` (so the logic lives in one place — SCHEMA_VERSION = highest `db/migrations/sql/*.up.sql`); the per-service `.goreleaser.yaml` (separate PRs) does the build/archive/checksum/release.

## Conventions

- Third-party actions **SHA-pinned + `# vX`** (S7637): `checkout@9c091bb… v7.0.0`, `setup-go@924ae3a… v6`, `goreleaser-action@5daf1e9… v7.2.2`.
- Scoped `permissions: contents: write`; `concurrency` (no cancel-in-progress for releases); `set -euo pipefail`.
- Action major **v7** ≠ GoReleaser **CLI** `~> v2` (intentional; commented).

## Verify

`actionlint` clean. Reviewed by the code-reviewer agent (contract verified end-to-end: `bin/` nesting, `checksum.split` → one `.sha256`, `build-info.env` attached via `release.extra_files`). Service callers reference `@main` (org convention).

Merge this first; the 8 service PRs (`.goreleaser.yaml` + `release.yml`) reference it.