### PR TITLE
Fix GoReleaser dirty-state abort on build-info.env

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -54,6 +54,10 @@ jobs:
         # sidecar. SCHEMA_VERSION = highest embedded migration (audit only).
         run: |
           set -euo pipefail
+          # Keep the generated sidecar out of git's view so GoReleaser's clean-state
+          # check doesn't abort on an untracked file (it's attached via extra_files,
+          # not committed). Local-only exclude — no tracked file is modified.
+          echo 'build-info.env' >> .git/info/exclude
           service="${GITHUB_REPOSITORY##*/}"; service="${service%-service}"
           version="${GITHUB_REF_NAME#v}"
           git_sha="$(git rev-parse --short HEAD)"


### PR DESCRIPTION
## Problem

Every `v*` release run on the 8 Go services failed at the GoReleaser step:

```
⨯ release failed after 0s  error=git is in a dirty state
  │ Please check in your pipeline what can be changing the following files:
  │ ?? build-info.env
```

The reusable workflow generates `build-info.env` in the repo root (an untracked file). GoReleaser's clean-state validation runs before the build and aborts on the dirty tree.

## Fix

Exclude the generated sidecar via `.git/info/exclude` (local-only — no tracked file is modified) so the working tree stays clean. The file is still attached to the GitHub Release through each repo's `.goreleaser.yaml` `extra_files` glob, so the `packages` artifact contract is unchanged.

One-line change in `.github/workflows/goreleaser.yml`; no service-repo changes needed. After merge, re-pushing the `v1.0.0` tags re-runs the release against `@main` cleanly.