### PR TITLE
ci: support test/ branches, integration-test job, and merged coverage

### DIFF
--- a/.github/workflows/go-check.yml
+++ b/.github/workflows/go-check.yml
@@ -45,6 +45,16 @@ on:
         type: boolean
         default: false
         description: Also test against stable Go version (non-blocking, for compatibility check)
+      integration:
+        required: false
+        type: boolean
+        default: false
+        description: Run integration tests (go test -tags=integration). Needs a Docker daemon (testcontainers); ubuntu-latest has one.
+      integration-command:
+        required: false
+        type: string
+        default: 'go test -tags=integration -covermode=atomic -coverprofile=coverage-integration.out ./...'
+        description: Command for the integration job. Must write coverage-integration.out (merged into SonarCloud coverage).
 
 
 jobs:
@@ -74,6 +84,33 @@ jobs:
         with:
           name: coverage-report
           path: coverage.out
+          retention-days: 1
+
+  integration:
+    name: Integration Test
+    if: ${{ inputs.integration }}
+    timeout-minutes: 30
+    runs-on: ${{ inputs.runs-on }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        if: ${{ inputs.setup-go }}
+        with:
+          go-version-file: ${{ inputs.gomod-path }}
+
+      # ubuntu-latest ships a running Docker daemon, so testcontainers works.
+      - name: Integration Test
+        run: ${{ inputs.integration-command }}
+
+      - name: Archive integration coverage
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: success()
+        with:
+          name: coverage-integration-report
+          path: coverage-integration.out
           retention-days: 1
 
   test-stable:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -34,8 +34,8 @@ jobs:
         # Allow standard gitflow/trunk-based prefixes.
         # HEAD_REF is passed via env (not interpolated into the script) to avoid
         # shell injection from an attacker-controlled branch name.
-        if [[ ! "$HEAD_REF" =~ ^(feature|feat|fix|bugfix|hotfix|release|chore|docs|refactor|dependabot|ci|renovate|build)\/ ]]; then
-          echo "Error: Source branch '$HEAD_REF' does not match allowed patterns (feat/*, fix/*, chore/*, etc.)"
+        if [[ ! "$HEAD_REF" =~ ^(feature|feat|fix|bugfix|hotfix|release|chore|docs|refactor|test|perf|dependabot|ci|renovate|build)\/ ]]; then
+          echo "Error: Source branch '$HEAD_REF' does not match allowed patterns (feat/*, fix/*, test/*, chore/*, etc.)"
           echo "Create a new branch with a valid prefix and open a new PR."
           exit 1
         fi

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -36,6 +36,16 @@ on:
         required: false
         type: string
         default: 'coverage-report'
+      coverage-exclusions:
+        description: 'Paths excluded from the coverage % only (still analyzed for bugs/smells): bootstrap/wiring/migrations/mocks.'
+        required: false
+        type: string
+        default: '**/cmd/**,**/internal/core/database.go,**/db/migrations/**,**/mocks/**,**/*_mock.go'
+      integration-coverage:
+        description: 'Merge integration coverage (coverage-integration.out from go-check.yml integration job) into the SonarCloud report.'
+        required: false
+        type: boolean
+        default: false
       runs-on:
         description: 'Runner type'
         required: false
@@ -81,6 +91,24 @@ jobs:
           name: ${{ inputs.artifact-name }}
           path: .
 
+      - name: Download integration coverage report
+        if: inputs.integration-coverage
+        continue-on-error: true # absent if the integration job was skipped/failed
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # tag: v8.0.1
+        with:
+          name: coverage-integration-report
+          path: .
+
+      - name: Resolve coverage report paths
+        id: cov
+        run: |
+          paths="${{ inputs.coverage-path }}"
+          if [ -f coverage-integration.out ]; then
+            paths="${paths},coverage-integration.out"
+          fi
+          echo "paths=${paths}" >> "$GITHUB_OUTPUT"
+          echo "coverage reportPaths: ${paths}"
+
       - name: SonarCloud Scan
         uses: sonarsource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # tag: v8.2.0
         with:
@@ -89,7 +117,8 @@ jobs:
             -Dsonar.organization=${{ inputs.organization }}
             -Dsonar.sources=${{ inputs.sources }}
             -Dsonar.exclusions=${{ inputs.exclusions }}
-            -Dsonar.go.coverage.reportPaths=${{ inputs.coverage-path }}
+            -Dsonar.coverage.exclusions=${{ inputs.coverage-exclusions }}
+            -Dsonar.go.coverage.reportPaths=${{ steps.cov.outputs.paths }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: https://sonarcloud.io


### PR DESCRIPTION
- pr-checks.yml: allow test/* and perf/* branch prefixes (Conventional Commits).
- go-check.yml: add optional integration job (inputs.integration) running go test -tags=integration on ubuntu-latest (Docker daemon present for testcontainers); uploads coverage-integration.out.
- sonarqube.yml: add coverage-exclusions (bootstrap/wiring/migrations/mocks excluded from the % only) and merge the integration coverage report into sonar.go.coverage.reportPaths so repository integration coverage counts.