### PR TITLE
ci(go-check): disable testcontainers Ryuk reaper on the integration job

### DIFF
--- a/.github/workflows/go-check.yml
+++ b/.github/workflows/go-check.yml
@@ -103,6 +103,12 @@ jobs:
 
       # ubuntu-latest ships a running Docker daemon, so testcontainers works.
       - name: Integration Test
+        # Disable the testcontainers Ryuk reaper on CI: the runner is ephemeral
+        # (no orphans to clean), and Ryuk's connect step intermittently hangs on
+        # GitHub runners — which timed out the whole job. Containers are still
+        # torn down by each test's t.Cleanup.
+        env:
+          TESTCONTAINERS_RYUK_DISABLED: "true"
         run: ${{ inputs.integration-command }}
 
       - name: Archive integration coverage


### PR DESCRIPTION
**Fix the integration job intermittently hanging.** order-service's integration job sat for 10 minutes with **no container created**, then timed out — the goroutine dump showed it stuck in `testcontainers (*Reaper).connect` (the Ryuk cleanup container). Ryuk's connect is a known flake on GitHub runners.

Ryuk only cleans **orphaned** containers, which is meaningless on an ephemeral CI runner (destroyed after the job); each test's `t.Cleanup` already terminates its Postgres container. Set `TESTCONTAINERS_RYUK_DISABLED=true` on the Integration Test step.

Diagnosed from the real CI log (run 28434712863). Applies to every service that uses the integration job (removes the flake for all, not just order).